### PR TITLE
PERF: default read_csv parallel workers to physical performance cores

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1544,8 +1544,12 @@ considerably. This happens automatically when all of the following hold:
 Calls that are not eligible fall back to the serial path, and the result is
 always identical to a serial read.
 
-The number of threads is controlled with the ``mode.max_threads`` option,
-which defaults to the number of CPU cores, capped at ``4``. On Windows the
+The number of threads is controlled with the ``mode.max_threads`` option. By
+default it uses the number of physical performance cores: the fast cluster on
+CPUs that have separate performance and efficiency cores (such as Apple
+silicon), and the physical core count otherwise. That default is limited to the
+CPUs available to the process (respecting CPU affinity and cgroup limits, so it
+behaves in containers and on shared machines) and to at most 16. On Windows the
 default is ``1`` (serial), as parallel reading currently does not improve
 performance there. Set the option to ``1`` to disable parallel reading, e.g.
 when pandas runs inside an application that already parallelizes work:

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -171,7 +171,7 @@ Performance improvements
 - Performance improvement in :func:`merge` with ``how="left"`` and ``sort=False`` when joining on a right index with unique keys (:issue:`65160`)
 - Performance improvement in :func:`merge` with ``sort=False`` for single-key ``how="left"``/``how="right"`` joins when the opposite join key is sorted, unique, and range-like (:issue:`64146`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` (:issue:`64515`)
-- Performance improvement in :func:`read_csv` with ``engine="c"`` for large uncompressed local files, which are now read in parallel across multiple CPU cores; this is enabled by default except on Windows and can be controlled with the ``mode.max_threads`` option (:issue:`64347`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` for large uncompressed local files, which are now read in parallel across the machine's physical performance cores (respecting CPU affinity and cgroup limits, and capped at 16); this is enabled by default (except on Windows) and can be controlled with the ``mode.max_threads`` option (:issue:`64347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, particularly when strings do not repeat (:issue:`65283`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing integer columns (:issue:`65347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when reading from binary file-like objects (e.g. PyArrow S3 file handles) by avoiding unnecessary ``TextIOWrapper`` wrapping (:issue:`46823`)

--- a/pandas/compat/_cpu.py
+++ b/pandas/compat/_cpu.py
@@ -1,0 +1,273 @@
+"""
+_cpu
+====
+
+Detection of a CPU's physical performance-core count.
+
+Used to pick the default worker count for parallel I/O.  The target is the
+number of *physical performance cores*: on a heterogeneous CPU (performance /
+efficiency clusters, e.g. Apple silicon or recent Intel client parts) that is
+the fast cluster, and on a homogeneous CPU it is simply the physical core count.
+Efficiency cores and SMT siblings are excluded because they do not speed up the
+memory-bandwidth-bound CSV parsing work (and an efficiency-core straggler slows
+the parallel gather down).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import functools
+import os
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def _parse_cpu_list(spec: str) -> list[int]:
+    """
+    Parse a Linux ``sysfs`` cpulist string into the CPU ids it names.
+
+    Handles the comma-and-range format, e.g. ``"0-5"`` -> ``[0, 1, 2, 3, 4, 5]``
+    and ``"0,2-3"`` -> ``[0, 2, 3]``.
+    """
+    ids: list[int] = []
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo, hi = part.split("-")
+            ids.extend(range(int(lo), int(hi) + 1))
+        else:
+            ids.append(int(part))
+    return ids
+
+
+def _count_distinct_cores(topology: Iterable[tuple[int, int] | None]) -> int | None:
+    """
+    Count distinct physical cores from ``(package_id, core_id)`` pairs.
+
+    ``None`` entries (unreadable topology) are ignored; returns ``None`` if no
+    pair could be read.
+    """
+    cores = {pair for pair in topology if pair is not None}
+    return len(cores) or None
+
+
+def _count_top_efficiency_class(
+    buf: ctypes.Array[ctypes.c_byte], length: int
+) -> int | None:
+    """
+    Count performance cores in a ``GetLogicalProcessorInformationEx`` buffer.
+
+    ``buf`` holds a sequence of ``SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX``
+    records (one per physical core): ``Size`` is a ``DWORD`` at offset ``+4`` and
+    ``PROCESSOR_RELATIONSHIP.EfficiencyClass`` is a ``BYTE`` at offset ``+9``.
+    The highest efficiency class is the performance cores.
+    """
+    addr = ctypes.addressof(buf)
+    offset = 0
+    eff_classes = []
+    while offset < length:
+        size = ctypes.c_uint32.from_address(addr + offset + 4).value
+        eff_classes.append(ctypes.c_uint8.from_address(addr + offset + 9).value)
+        if size == 0:
+            break
+        offset += size
+    if not eff_classes:
+        return None
+    top = max(eff_classes)
+    return sum(1 for cls in eff_classes if cls == top)
+
+
+def _sysctl_int(name: bytes) -> int | None:
+    """Read an integer ``sysctl`` by name on macOS, or None on failure."""
+    try:
+        libc = ctypes.CDLL("libc.dylib", use_errno=True)
+        val = ctypes.c_int(0)
+        size = ctypes.c_size_t(ctypes.sizeof(val))
+        rc = libc.sysctlbyname(name, ctypes.byref(val), ctypes.byref(size), None, 0)
+        if rc == 0 and val.value > 0:
+            return val.value
+    except (OSError, ValueError):
+        pass
+    return None
+
+
+def _perf_cores_darwin() -> int | None:
+    """Physical performance cores on macOS (P-cluster on hybrid, else all)."""
+    # perflevel0 is the highest-performance cluster on Apple silicon; on a
+    # homogeneous CPU (e.g. an Intel Mac) it is absent, so fall back to the
+    # overall physical core count.
+    for name in (b"hw.perflevel0.physicalcpu", b"hw.physicalcpu"):
+        val = _sysctl_int(name)
+        if val is not None:
+            return val
+    return None
+
+
+def _read_sysfs_int(path: str) -> int | None:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return int(fh.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _read_sysfs_str(path: str) -> str | None:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read().strip()
+    except OSError:
+        return None
+
+
+def _cpu_topology(cpu: int) -> tuple[int, int] | None:
+    """``(physical_package_id, core_id)`` for a logical CPU, or None."""
+    base = f"/sys/devices/system/cpu/cpu{cpu}/topology"
+    pkg = _read_sysfs_int(f"{base}/physical_package_id")
+    core = _read_sysfs_int(f"{base}/core_id")
+    if pkg is None or core is None:
+        return None
+    return (pkg, core)
+
+
+def _perf_logical_cpus_linux() -> list[int]:
+    """Logical CPU ids that belong to the performance cluster on Linux."""
+    # Intel hybrid parts expose the performance cores via a dedicated driver dir.
+    spec = _read_sysfs_str("/sys/devices/cpu_core/cpus")
+    if spec:
+        ids = _parse_cpu_list(spec)
+        if ids:
+            return ids
+    # Homogeneous (or non-Intel): every present CPU is a performance core.
+    spec = _read_sysfs_str("/sys/devices/system/cpu/present")
+    if spec:
+        return _parse_cpu_list(spec)
+    return []
+
+
+def _perf_cores_linux() -> int | None:
+    """Physical performance cores on Linux (SMT siblings collapsed)."""
+    logical = _perf_logical_cpus_linux()
+    if not logical:
+        return None
+    physical = _count_distinct_cores(_cpu_topology(cpu) for cpu in logical)
+    if physical is not None:
+        return physical
+    # Topology unreadable: fall back to the logical performance-CPU count.
+    return len(logical)
+
+
+def _perf_cores_windows() -> int | None:
+    """Physical performance cores on Windows, or None."""
+    if sys.platform != "win32":
+        return None
+    # GetLogicalProcessorInformationEx(RelationProcessorCore) reports an
+    # EfficiencyClass per physical core; the highest class is the performance
+    # cores.
+    try:
+        from ctypes import wintypes
+
+        relation_processor_core = 0
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        get_info = kernel32.GetLogicalProcessorInformationEx
+        length = wintypes.DWORD(0)
+        get_info(relation_processor_core, None, ctypes.byref(length))
+        buf = (ctypes.c_byte * length.value)()
+        if not get_info(relation_processor_core, buf, ctypes.byref(length)):
+            return None
+        return _count_top_efficiency_class(buf, length.value)
+    except Exception:
+        return None
+
+
+def _parse_cgroup_v2_quota(text: str) -> float | None:
+    """
+    CPU count from a cgroup v2 ``cpu.max`` value.
+
+    The format is ``"<quota> <period>"`` (both in microseconds) or ``"max"`` when
+    the CPU time is unlimited; returns ``None`` when unlimited or malformed.
+    """
+    parts = text.split()
+    if not parts or parts[0] == "max":
+        return None
+    try:
+        quota = int(parts[0])
+        period = int(parts[1]) if len(parts) > 1 else 100000
+    except ValueError:
+        return None
+    if quota > 0 and period > 0:
+        return quota / period
+    return None
+
+
+def _cgroup_cpu_quota() -> float | None:
+    """CPUs allowed by the process's cgroup CFS quota, or None if unlimited."""
+    # cgroup v2; under a cgroup namespace (the common container case) this is the
+    # limit the container itself sees.
+    text = _read_sysfs_str("/sys/fs/cgroup/cpu.max")
+    if text is not None:
+        return _parse_cgroup_v2_quota(text)
+    # cgroup v1
+    quota = _read_sysfs_int("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+    period = _read_sysfs_int("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+    if quota and quota > 0 and period and period > 0:
+        return quota / period
+    return None
+
+
+@functools.lru_cache(maxsize=1)
+def available_cpu_count() -> int | None:
+    """
+    Number of CPUs the process may actually use, or None if unconstrained.
+
+    Takes the tighter of the CPU affinity mask (``taskset``, SLURM cpusets) and
+    the cgroup CFS quota (Docker ``--cpus``, Kubernetes CPU limits), so a default
+    worker count does not oversubscribe a restricted environment.  Returns
+    ``None`` on platforms/setups without either limit (e.g. macOS, Windows, or an
+    unconstrained Linux box).
+
+    Cached for the process lifetime: the CPU allocation is effectively static
+    (cgroup limits do not change at runtime and affinity is normally set once at
+    startup), and this is on the ``read_csv`` hot path.
+    """
+    limits = []
+    if hasattr(os, "sched_getaffinity"):
+        try:
+            limits.append(len(os.sched_getaffinity(0)))
+        except OSError:
+            pass
+    quota = _cgroup_cpu_quota()
+    if quota is not None:
+        limits.append(max(1, int(quota)))
+    return min(limits) if limits else None
+
+
+@functools.lru_cache(maxsize=1)
+def performance_core_count() -> int:
+    """
+    Return the number of physical performance cores available to the process.
+
+    On heterogeneous CPUs (e.g. Apple silicon or recent Intel client parts with
+    performance/efficiency clusters) this is the size of the fast cluster.  On
+    homogeneous CPUs it is the physical core count.  Whenever the platform probe
+    is unavailable or fails, this falls back to :func:`os.cpu_count`.
+
+    The result is cached for the lifetime of the process.
+    """
+    total = os.cpu_count() or 1
+    probe = {
+        "darwin": _perf_cores_darwin,
+        "linux": _perf_cores_linux,
+        "win32": _perf_cores_windows,
+    }.get(sys.platform)
+    try:
+        n_perf = probe() if probe is not None else None
+    except Exception:
+        n_perf = None
+    if n_perf is None or n_perf < 1 or n_perf > total:
+        return total
+    return n_perf

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -461,10 +461,13 @@ with cf.config_prefix("mode"):
 max_threads_doc = """
 : int or None
     Maximum number of worker threads for parallel operations (e.g. ``read_csv``
-    for large files).  ``None`` (the default) means use ``min(os.cpu_count(), 4)``.
-    Set to ``1`` to disable parallel execution, or to a fixed number to raise the
-    cap or to limit thread usage when pandas is embedded in a larger parallel
-    workflow.
+    for large files).  ``None`` (the default) uses the number of physical
+    performance cores (the fast cluster on CPUs with performance/efficiency
+    clusters, and the physical core count otherwise), limited to the CPUs
+    available to the process (CPU affinity and cgroup limits) and to at most 16.
+    Set to ``1`` to disable parallel execution, or to a fixed number to raise or
+    lower the worker count, e.g. to limit thread usage when pandas is embedded in
+    a larger parallel workflow.
 """
 
 

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -38,6 +38,10 @@ from pandas._config import get_option
 
 from pandas._libs import lib
 from pandas._libs.parsers import STR_NA_VALUES
+from pandas.compat._cpu import (
+    available_cpu_count,
+    performance_core_count,
+)
 from pandas.errors import (
     AbstractMethodError,
     Pandas4Warning,
@@ -183,6 +187,13 @@ _python_unsupported = {"low_memory", "float_precision"}
 # Minimum file size (bytes) to attempt parallel CSV reading.
 # Below this threshold the overhead of splitting and threading outweighs the benefit.
 _PARALLEL_READ_MIN_BYTES = 50 * 1024 * 1024  # 50 MB
+
+# Upper bound on the default parallel-read worker count.  Chosen as a ceiling
+# comfortably above any current client CPU's performance-core count, so it never
+# limits a normal machine but stops a default read from oversubscribing a large
+# shared server that has no cgroup/affinity limit set.  Users who genuinely want
+# more can raise it via mode.max_threads.
+_MAX_DEFAULT_WORKERS = 16
 _pyarrow_unsupported = {
     "skipfooter",
     "float_precision",
@@ -324,26 +335,7 @@ def _read(
     # Each worker gets its own file handle and TextReader so the GIL-free tokenisation
     # and type-conversion code in parsers.pyx runs truly in parallel.
     if not iterator and chunksize is None and nrows is None:
-        _max = get_option("mode.max_threads")
-        if sys.platform == "emscripten":
-            # WASM cannot spawn threads, regardless of mode.max_threads.
-            _n_workers = 1
-        elif _max is not None:
-            _n_workers = _max
-        elif sys.platform == "win32":
-            # Parallel CSV reading does not currently speed up on Windows: even
-            # with the file warm in the OS cache, using more than one thread is
-            # no faster (and slower at two threads).  Default to serial there;
-            # users can still opt in explicitly via mode.max_threads.  See the
-            # benchmark numbers in the GH#64347 discussion:
-            # https://github.com/pandas-dev/pandas/pull/64347#issuecomment-4468820601
-            _n_workers = 1
-        else:
-            # Cap the default at 4 threads: parallel CSV reading sees
-            # diminishing returns beyond a handful of workers, and a lower
-            # default avoids oversubscribing the machine.  Users who want more
-            # can opt in explicitly via mode.max_threads.
-            _n_workers = min(os.cpu_count() or 1, 4)
+        _n_workers = _default_n_workers()
         if _n_workers > 1 and _can_parallelize_csv(filepath_or_buffer, kwds):
             _filepath = stringify_path(filepath_or_buffer)
             assert isinstance(_filepath, str)  # guaranteed by _can_parallelize_csv
@@ -366,6 +358,42 @@ def _read(
 
     with parser:
         return parser.read(nrows)
+
+
+def _default_n_workers() -> int:
+    """
+    Default worker count for a parallel ``read_csv``.
+
+    ``mode.max_threads`` wins whenever it is set (except on WASM, which cannot
+    spawn threads at all).  Otherwise parallel reading is off by default on
+    Windows, and elsewhere defaults to the number of physical performance cores
+    (:func:`~pandas.compat._cpu.performance_core_count`): the fast cluster on a
+    heterogeneous P/E-core CPU, or the physical core count on a homogeneous one.
+    Efficiency cores and SMT siblings are excluded because they do not speed up
+    the memory-bandwidth-bound parse (and a slow efficiency-core chunk becomes
+    the straggler the gather waits on).  That count is then clamped to the CPUs
+    actually available to the process (CPU affinity / cgroup limits) and to
+    ``_MAX_DEFAULT_WORKERS``.
+    """
+    max_threads = get_option("mode.max_threads")
+    if sys.platform == "emscripten":
+        # WASM cannot spawn threads, regardless of mode.max_threads.
+        return 1
+    if max_threads is not None:
+        return max_threads
+    if sys.platform == "win32":
+        # Parallel CSV reading does not currently speed up on Windows: even
+        # with the file warm in the OS cache, using more than one thread is
+        # no faster (and slower at two threads).  Default to serial there;
+        # users can still opt in explicitly via mode.max_threads.  See the
+        # benchmark numbers in the GH#64347 discussion:
+        # https://github.com/pandas-dev/pandas/pull/64347#issuecomment-4468820601
+        return 1
+    n_workers = performance_core_count()
+    available = available_cpu_count()
+    if available is not None:
+        n_workers = min(n_workers, available)
+    return min(n_workers, _MAX_DEFAULT_WORKERS)
 
 
 def _can_parallelize_csv(filepath_or_buffer, kwds: dict) -> bool:

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -13,6 +13,7 @@ We test correctness (parallel == serial) rather than performance.
 from __future__ import annotations
 
 import csv
+import ctypes
 import io
 import os
 from typing import TYPE_CHECKING
@@ -20,6 +21,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pytest
 
+from pandas.compat._cpu import (
+    _count_distinct_cores,
+    _count_top_efficiency_class,
+    _parse_cgroup_v2_quota,
+    _parse_cpu_list,
+    available_cpu_count,
+    performance_core_count,
+)
 from pandas.errors import (
     ParserError,
     ParserWarning,
@@ -38,6 +47,7 @@ import pandas._testing as tm
 from pandas.io.parsers.base_parser import ParserBase
 from pandas.io.parsers.readers import (
     _can_parallelize_csv,
+    _default_n_workers,
     _find_chunk_byte_offsets,
     _find_data_start_offset,
     _read_csv_parallel,
@@ -696,8 +706,10 @@ def test_parallel_default_off_on_windows(tmp_path, monkeypatch):
     _make_large_csv(path)
     monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
     # Pin the non-Windows default so the test does not depend on the host's
-    # actual core count.
+    # actual core count / topology / cgroup limits.
     monkeypatch.setattr(_readers.os, "cpu_count", lambda: 4)
+    monkeypatch.setattr(_readers, "performance_core_count", lambda: 4)
+    monkeypatch.setattr(_readers, "available_cpu_count", lambda: None)
 
     # Stub the parallel reader so this exercises only the platform-gating
     # decision.  Calling the real one would start threads, which fails on
@@ -719,16 +731,19 @@ def test_parallel_default_off_on_windows(tmp_path, monkeypatch):
     assert len(calls) == 1  # parallel by default elsewhere
 
 
-def test_parallel_default_thread_cap(tmp_path, monkeypatch):
-    """The default worker count is capped at 4, regardless of core count."""
+def test_parallel_default_uses_performance_cores(tmp_path, monkeypatch):
+    """The default worker count follows the detected physical performance cores."""
     import pandas.io.parsers.readers as _readers
 
     path = tmp_path / "big.csv"
     _make_large_csv(path)
     monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
     monkeypatch.setattr(_readers.sys, "platform", "linux")
-    # More cores than the cap: the default should clamp down to 4.
+    # 6 performance cores out of 16 logical CPUs: the default follows the fast
+    # cluster, not the full logical core count.
     monkeypatch.setattr(_readers.os, "cpu_count", lambda: 16)
+    monkeypatch.setattr(_readers, "performance_core_count", lambda: 6)
+    monkeypatch.setattr(_readers, "available_cpu_count", lambda: None)
 
     workers = []
 
@@ -739,9 +754,9 @@ def test_parallel_default_thread_cap(tmp_path, monkeypatch):
     monkeypatch.setattr(_readers, "_read_csv_parallel", stub)
 
     read_csv(path)
-    assert workers == [4]
+    assert workers == [6]
 
-    # An explicit mode.max_threads still overrides the cap.
+    # An explicit mode.max_threads still overrides the performance-core default.
     workers.clear()
     with option_context("mode.max_threads", 8):
         read_csv(path)
@@ -1006,3 +1021,332 @@ def test_parallel_bom_at_file_start_header_none(tmp_path, monkeypatch):
     tm.assert_frame_equal(result, expected)
     # the stripped BOM means the first cell parses as an integer
     assert result["a"].iloc[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# Performance-core detection and the default worker count
+# ---------------------------------------------------------------------------
+
+
+def test_performance_core_count_within_bounds():
+    # Whatever the host topology, the detector returns a positive int no larger
+    # than the logical CPU count, and never raises.
+    performance_core_count.cache_clear()
+    try:
+        n_perf = performance_core_count()
+    finally:
+        performance_core_count.cache_clear()
+    assert isinstance(n_perf, int)
+    assert 1 <= n_perf <= (os.cpu_count() or 1)
+
+
+@pytest.mark.parametrize(
+    "platform_name, probe_name",
+    [
+        ("darwin", "_perf_cores_darwin"),
+        ("linux", "_perf_cores_linux"),
+        ("win32", "_perf_cores_windows"),
+    ],
+)
+@pytest.mark.parametrize("failure", ["returns_none", "raises"])
+def test_performance_core_count_falls_back(
+    monkeypatch, platform_name, probe_name, failure
+):
+    # A probe that returns None or raises must fall back to os.cpu_count().
+    from pandas.compat import _cpu
+
+    def probe():
+        if failure == "raises":
+            raise OSError("probe failed")
+
+    monkeypatch.setattr(_cpu.sys, "platform", platform_name)
+    monkeypatch.setattr(_cpu, probe_name, probe)
+    _cpu.performance_core_count.cache_clear()
+    try:
+        assert _cpu.performance_core_count() == (os.cpu_count() or 1)
+    finally:
+        _cpu.performance_core_count.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "probe_result, expected",
+    [
+        (1, 1),  # a valid subset is used as-is
+        (0, "total"),  # nonsensical count -> fall back
+        (10**6, "total"),  # more cores than exist -> fall back
+    ],
+)
+def test_performance_core_count_validates_probe(monkeypatch, probe_result, expected):
+    from pandas.compat import _cpu
+
+    total = os.cpu_count() or 1
+    monkeypatch.setattr(_cpu.sys, "platform", "darwin")
+    monkeypatch.setattr(_cpu, "_perf_cores_darwin", lambda: probe_result)
+    _cpu.performance_core_count.cache_clear()
+    try:
+        result = _cpu.performance_core_count()
+    finally:
+        _cpu.performance_core_count.cache_clear()
+    assert result == (total if expected == "total" else expected)
+
+
+@pytest.mark.parametrize(
+    "n_perf, available, expected",
+    [
+        (6, None, 6),  # unconstrained, below the cap -> detected count
+        (1, None, 1),
+        (24, None, 16),  # e.g. an M-series Ultra -> capped
+        (32, None, 16),  # cap binds
+        (8, 4, 4),  # cgroup/affinity tighter than the perf-core count
+        (8, 12, 8),  # allocation looser than the perf-core count
+        (32, 8, 8),  # allocation tighter than both cap and perf cores
+    ],
+)
+def test_default_n_workers_combines_detection_allocation_cap(
+    monkeypatch, n_perf, available, expected
+):
+    # Default = min(physical performance cores, available CPUs, _MAX_DEFAULT_WORKERS).
+    import pandas.io.parsers.readers as _readers
+
+    assert _readers._MAX_DEFAULT_WORKERS == 16
+    monkeypatch.setattr(_readers.sys, "platform", "linux")
+    monkeypatch.setattr(_readers, "performance_core_count", lambda: n_perf)
+    monkeypatch.setattr(_readers, "available_cpu_count", lambda: available)
+    with option_context("mode.max_threads", None):
+        assert _default_n_workers() == expected
+
+
+def test_default_n_workers_windows_is_serial(monkeypatch):
+    import pandas.io.parsers.readers as _readers
+
+    monkeypatch.setattr(_readers.sys, "platform", "win32")
+    monkeypatch.setattr(_readers.os, "cpu_count", lambda: 12)
+    monkeypatch.setattr(_readers, "performance_core_count", lambda: 6)
+    with option_context("mode.max_threads", None):
+        assert _default_n_workers() == 1
+
+
+def test_default_n_workers_wasm_is_serial(monkeypatch):
+    import pandas.io.parsers.readers as _readers
+
+    monkeypatch.setattr(_readers.sys, "platform", "emscripten")
+    # WASM stays serial even if a worker count is requested explicitly.
+    with option_context("mode.max_threads", 8):
+        assert _default_n_workers() == 1
+
+
+@pytest.mark.parametrize("platform_name", ["linux", "win32"])
+def test_default_n_workers_max_threads_wins(monkeypatch, platform_name):
+    import pandas.io.parsers.readers as _readers
+
+    monkeypatch.setattr(_readers.sys, "platform", platform_name)
+    monkeypatch.setattr(_readers.os, "cpu_count", lambda: 12)
+    monkeypatch.setattr(_readers, "performance_core_count", lambda: 6)
+    with option_context("mode.max_threads", 3):
+        assert _default_n_workers() == 3
+
+
+@pytest.mark.parametrize(
+    "spec, expected",
+    [
+        ("0-5", [0, 1, 2, 3, 4, 5]),
+        ("0-3,8", [0, 1, 2, 3, 8]),
+        ("0,2,4", [0, 2, 4]),
+        ("3", [3]),
+        ("", []),
+    ],
+)
+def test_parse_cpu_list(spec, expected):
+    assert _parse_cpu_list(spec) == expected
+
+
+@pytest.mark.parametrize(
+    "topology, expected",
+    [
+        # 4 SMT threads -> 2 physical cores (siblings collapse by (pkg, core)).
+        ([(0, 0), (0, 0), (0, 1), (0, 1)], 2),
+        # two packages, one core each
+        ([(0, 0), (1, 0)], 2),
+        # unreadable entries are ignored
+        ([(0, 0), None, (0, 0)], 1),
+        ([None, None], None),
+        ([], None),
+    ],
+)
+def test_count_distinct_cores(topology, expected):
+    assert _count_distinct_cores(topology) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("max 100000", None),  # unlimited
+        ("max", None),
+        ("400000 100000", 4.0),
+        ("150000 100000", 1.5),
+        ("100000", 1.0),  # period defaults to 100000us
+        ("0 100000", None),  # zero quota -> ignored
+        ("garbage", None),
+        ("", None),
+    ],
+)
+def test_parse_cgroup_v2_quota(text, expected):
+    assert _parse_cgroup_v2_quota(text) == expected
+
+
+@pytest.mark.parametrize(
+    "affinity, quota, expected",
+    [
+        ({0, 1, 2, 3, 4, 5, 6, 7}, None, 8),  # affinity only
+        ({0, 1, 2, 3, 4, 5, 6, 7}, 4.0, 4),  # cgroup quota tighter
+        ({0, 1, 2, 3}, 8.0, 4),  # affinity tighter
+        ({0, 1}, 1.5, 1),  # fractional quota floors, min 1
+    ],
+)
+def test_available_cpu_count(monkeypatch, affinity, quota, expected):
+    from pandas.compat import _cpu
+
+    monkeypatch.setattr(
+        os, "sched_getaffinity", lambda pid: set(affinity), raising=False
+    )
+    monkeypatch.setattr(_cpu, "_cgroup_cpu_quota", lambda: quota)
+    available_cpu_count.cache_clear()
+    try:
+        assert available_cpu_count() == expected
+    finally:
+        available_cpu_count.cache_clear()
+
+
+def test_available_cpu_count_unconstrained(monkeypatch):
+    # No affinity limit and no cgroup quota -> None (do not clamp).
+    from pandas.compat import _cpu
+
+    def raise_oserror(pid):
+        raise OSError
+
+    monkeypatch.setattr(os, "sched_getaffinity", raise_oserror, raising=False)
+    monkeypatch.setattr(_cpu, "_cgroup_cpu_quota", lambda: None)
+    available_cpu_count.cache_clear()
+    try:
+        assert available_cpu_count() is None
+    finally:
+        available_cpu_count.cache_clear()
+
+
+def _fake_cpu_topology_reader(cores_per_cpu):
+    """Build a fake ``_read_sysfs_int`` returning core/package ids from a map."""
+    import re
+
+    def read_int(path):
+        match = re.search(r"/cpu(\d+)/topology/(\w+)", path)
+        if match is None:
+            return None
+        cpu, field = int(match.group(1)), match.group(2)
+        if field == "physical_package_id":
+            return 0
+        if field == "core_id":
+            return cores_per_cpu.get(cpu)
+        return None
+
+    return read_int
+
+
+def test_perf_cores_linux_hybrid_collapses_smt(monkeypatch):
+    # 8 logical P-CPUs (0-7) that are 4 physical cores with 2 SMT threads each.
+    from pandas.compat import _cpu
+
+    strs = {"/sys/devices/cpu_core/cpus": "0-7"}
+    cores = {cpu: cpu // 2 for cpu in range(8)}
+    monkeypatch.setattr(_cpu, "_read_sysfs_str", lambda path: strs.get(path))
+    monkeypatch.setattr(_cpu, "_read_sysfs_int", _fake_cpu_topology_reader(cores))
+    assert _cpu._perf_cores_linux() == 4
+
+
+def test_perf_cores_linux_homogeneous_uses_present(monkeypatch):
+    # No hybrid P-core dir: fall back to all present CPUs (0-3 = 2 physical cores).
+    from pandas.compat import _cpu
+
+    strs = {
+        "/sys/devices/cpu_core/cpus": None,
+        "/sys/devices/system/cpu/present": "0-3",
+    }
+    cores = {cpu: cpu // 2 for cpu in range(4)}
+    monkeypatch.setattr(_cpu, "_read_sysfs_str", lambda path: strs.get(path))
+    monkeypatch.setattr(_cpu, "_read_sysfs_int", _fake_cpu_topology_reader(cores))
+    assert _cpu._perf_cores_linux() == 2
+
+
+def test_cgroup_cpu_quota_v2(monkeypatch):
+    from pandas.compat import _cpu
+
+    monkeypatch.setattr(
+        _cpu,
+        "_read_sysfs_str",
+        lambda path: "400000 100000" if path == "/sys/fs/cgroup/cpu.max" else None,
+    )
+    assert _cpu._cgroup_cpu_quota() == 4.0
+
+
+def test_cgroup_cpu_quota_v1_fallback(monkeypatch):
+    from pandas.compat import _cpu
+
+    ints = {
+        "/sys/fs/cgroup/cpu/cpu.cfs_quota_us": 300000,
+        "/sys/fs/cgroup/cpu/cpu.cfs_period_us": 100000,
+    }
+    monkeypatch.setattr(_cpu, "_read_sysfs_str", lambda path: None)  # no cgroup v2
+    monkeypatch.setattr(_cpu, "_read_sysfs_int", lambda path: ints.get(path))
+    assert _cpu._cgroup_cpu_quota() == 3.0
+
+
+def test_cgroup_cpu_quota_unlimited(monkeypatch):
+    from pandas.compat import _cpu
+
+    monkeypatch.setattr(
+        _cpu,
+        "_read_sysfs_str",
+        lambda path: "max 100000" if path == "/sys/fs/cgroup/cpu.max" else None,
+    )
+    monkeypatch.setattr(_cpu, "_read_sysfs_int", lambda path: None)
+    assert _cpu._cgroup_cpu_quota() is None
+
+
+def _make_win_processor_buffer(records):
+    """Build a synthetic ``GetLogicalProcessorInformationEx`` buffer.
+
+    ``records`` is a list of ``(size, efficiency_class)`` pairs, one per
+    physical-core relationship record.  ``Size`` sits at byte offset ``+4`` and
+    ``EfficiencyClass`` at ``+9`` within each record.
+    """
+    total = sum(size for size, _ in records)
+    buf = (ctypes.c_byte * total)()
+    addr = ctypes.addressof(buf)
+    offset = 0
+    for size, eff in records:
+        ctypes.c_uint32.from_address(addr + offset + 4).value = size
+        ctypes.c_uint8.from_address(addr + offset + 9).value = eff
+        offset += size
+    return buf, total
+
+
+def test_count_top_efficiency_class_hybrid():
+    # 4 performance cores (class 1) + 4 efficiency cores (class 0).
+    buf, length = _make_win_processor_buffer([(32, 1)] * 4 + [(32, 0)] * 4)
+    assert _count_top_efficiency_class(buf, length) == 4
+
+
+def test_count_top_efficiency_class_homogeneous():
+    # All cores share one efficiency class -> every core counts.
+    buf, length = _make_win_processor_buffer([(32, 0)] * 8)
+    assert _count_top_efficiency_class(buf, length) == 8
+
+
+def test_count_top_efficiency_class_variable_record_size():
+    # Records advance by their own Size field, not a fixed stride.
+    buf, length = _make_win_processor_buffer([(40, 1), (24, 1), (32, 0)])
+    assert _count_top_efficiency_class(buf, length) == 2
+
+
+def test_count_top_efficiency_class_empty():
+    buf = (ctypes.c_byte * 0)()
+    assert _count_top_efficiency_class(buf, 0) is None


### PR DESCRIPTION
Stacked on GH-64347 (parallel `read_csv`). Base is the `perf-read_csv` branch so this diff is just the incremental change; retarget to `main` once GH-64347 merges.

Refines the default worker count for the parallel C-engine `read_csv` path. Instead of a flat `min(os.cpu_count(), 4)`, the default is the number of **physical performance cores** — the fast cluster on heterogeneous P/E-core CPUs (Apple silicon, recent Intel client parts) and the physical core count on homogeneous CPUs — clamped to the CPUs available to the process (CPU affinity and cgroup CFS quota) and to at most 16.

**Why:** on a 6P+6E M3 Pro the `read_csv` speedup knee sits at the performance-core count (~6). The old cap of 4 left 14–33% on the table (floats / mixed / wide reads), and scheduling past the P-cores onto efficiency cores regresses — a slow E-core chunk becomes the straggler the parallel gather waits on. Efficiency cores and SMT siblings are excluded because they do not speed up the memory-bandwidth-bound parse. The affinity/cgroup clamp keeps containers (Docker `--cpus`, Kubernetes CPU limits) and cpuset-restricted jobs from oversubscribing; the cap of 16 bounds large bare shared servers.

Detection lives in a new `pandas/compat/_cpu.py` (`performance_core_count`, `available_cpu_count`) with graceful fallback to `os.cpu_count()` on any probe failure. `mode.max_threads` still overrides everything, and the Windows serial default is unchanged. Updates GH-64347's whatsnew entry in place.

Prior art checked: pyarrow / polars / duckdb all default to logical cores with no small cap and no P/E awareness; polars (via Rust `available_parallelism`) and joblib handle the container case via cgroup/affinity, which this mirrors without adding a dependency.
